### PR TITLE
Generate Meme from URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "homepage": "https://st6.io/meme",
   "dependencies": {
+    "is-image-url": "1.1.8",
     "react": "16.8.6",
+    "react-addons-css-transition-group": "15.6.2",
     "react-dom": "16.8.6",
     "react-icons": "3.5.0",
     "react-scripts": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "save-svg-as-png": "st6io/saveSvgAsPng#meme-fixes",
     "styled-components": "4.1.3",
     "typeface-oswald": "0.0.54",
-    "url": "0.11.0",
     "use-media": "1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "dependencies": {
     "is-image": "3.0.0",
     "react": "16.8.6",
-    "react-addons-css-transition-group": "15.6.2",
     "react-dom": "16.8.6",
     "react-icons": "3.5.0",
     "react-scripts": "3.0.0",
+    "react-transition-group": "4.0.1",
     "rebass": "3.0.1",
     "save-svg-as-png": "st6io/saveSvgAsPng#meme-fixes",
     "styled-components": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://st6.io/meme",
   "dependencies": {
-    "is-image-url": "1.1.8",
+    "is-image": "3.0.0",
     "react": "16.8.6",
     "react-addons-css-transition-group": "15.6.2",
     "react-dom": "16.8.6",
@@ -14,6 +14,7 @@
     "save-svg-as-png": "st6io/saveSvgAsPng#meme-fixes",
     "styled-components": "4.1.3",
     "typeface-oswald": "0.0.54",
+    "url": "0.11.0",
     "use-media": "1.2.0"
   },
   "devDependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -5,8 +5,6 @@ import { FaUpload, FaRandom, FaGithub, FaLink } from 'react-icons/fa';
 import { saveSvgAsPng } from 'save-svg-as-png';
 import { useMedia } from 'use-media';
 
-import isImageUrl from './utils/is-image-url';
-
 import {
   GlobalStyle,
   Meme,
@@ -18,6 +16,7 @@ import {
 } from './components';
 import { getRandomMeme } from './memes';
 import { websiteUrl, githubUrl } from './utils/links';
+import isImageUrl from './utils/is-image-url';
 
 const onTextInputChange = setter => ({ target: { value } }) => setter(value);
 
@@ -38,14 +37,13 @@ const MemeContainer = styled(Flex)`
 `;
 
 const DEFAULT_IMG_URL = '';
-const HIDDEN_IMG_URL_INPUT = false;
 
 const bypassCorsUrl = url => `https://meme.st6.io/meme-image?imageUrl=${url}`;
 
 const App = () => {
   const isMobile = useMedia({ maxWidth: '40em' });
   const [theme, setTheme] = useState('light');
-  const [showUrlInput, setShowUrlInput] = useState(HIDDEN_IMG_URL_INPUT);
+  const [showUrlInput, setShowUrlInput] = useState(false);
   const [topLabel, setTopLabel] = useState('Do the most meaningful meme...');
   const [bottomLabel, setBottomLabel] = useState('...of your life');
   const [imageUrl, setImageUrl] = useState(DEFAULT_IMG_URL);
@@ -54,8 +52,8 @@ const App = () => {
 
   const hideUrlInput = useCallback(() => {
     setImageUrl(DEFAULT_IMG_URL);
-    setShowUrlInput(HIDDEN_IMG_URL_INPUT);
-  }, [setImageUrl, setShowUrlInput]);
+    setShowUrlInput(false);
+  }, []);
 
   useLayoutEffect(
     () => {

--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,7 @@ const bypassCorsUrl = url => `https://meme.st6.io/meme-image?imageUrl=${url}`;
 const App = () => {
   const isMobile = useMedia({ maxWidth: '40em' });
   const [theme, setTheme] = useState('light');
-  const [showUrlInput, setShowUrlInput] = useState(false);
+  const [urlInputVisible, setUrlInputVisible] = useState(false);
   const [topLabel, setTopLabel] = useState('Do the most meaningful meme...');
   const [bottomLabel, setBottomLabel] = useState('...of your life');
   const [imageUrl, setImageUrl] = useState(DEFAULT_IMG_URL);
@@ -52,12 +52,12 @@ const App = () => {
 
   const hideUrlInput = useCallback(() => {
     setImageUrl(DEFAULT_IMG_URL);
-    setShowUrlInput(false);
+    setUrlInputVisible(false);
   }, []);
 
   useLayoutEffect(
     () => {
-      if (showUrlInput && isImageUrl(imageUrl)) {
+      if (urlInputVisible && isImageUrl(imageUrl)) {
         const downloadImageUrl = bypassCorsUrl(imageUrl);
         if (imageSrc === downloadImageUrl) {
           hideUrlInput();
@@ -72,7 +72,7 @@ const App = () => {
     // applied as image source which would hide the input
     // even though the image might not be loaded, yet
     /* eslint-disable react-hooks/exhaustive-deps */ [
-      showUrlInput,
+      urlInputVisible,
       imageUrl,
       hideUrlInput,
     ],
@@ -149,7 +149,7 @@ const App = () => {
               variant="outline"
               title="Image From URL"
               ml={3}
-              onClick={() => setShowUrlInput(!showUrlInput)}
+              onClick={() => setUrlInputVisible(!urlInputVisible)}
             >
               <FaLink />
             </Button>
@@ -175,7 +175,7 @@ const App = () => {
           </Flex>
 
           <ImageUrlInput
-            visible={showUrlInput}
+            visible={urlInputVisible}
             value={imageUrl}
             onChange={useCallback(onTextInputChange(setImageUrl), [
               setImageUrl,

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useLayoutEffect, useRef, useCallback } from 'react';
 import { Heading, Card, Flex, Box, Button } from 'rebass';
 import styled, { ThemeProvider } from 'styled-components/macro';
 import { FaUpload, FaRandom, FaGithub, FaLink } from 'react-icons/fa';
 import { saveSvgAsPng } from 'save-svg-as-png';
 import { useMedia } from 'use-media';
-import isImageUrl from 'is-image-url';
+
+import isImageUrl from './utils/is-image-url';
 
 import {
   GlobalStyle,
@@ -56,7 +57,7 @@ const App = () => {
     setShowUrlInput(HIDDEN_IMG_URL_INPUT);
   }, [setImageUrl, setShowUrlInput]);
 
-  useEffect(
+  useLayoutEffect(
     () => {
       if (showUrlInput && isImageUrl(imageUrl)) {
         const downloadImageUrl = bypassCorsUrl(imageUrl);
@@ -176,11 +177,11 @@ const App = () => {
           </Flex>
 
           <ImageUrlInput
-            variant="primary"
-            placeholder="Image URL..."
             visible={showUrlInput}
             value={imageUrl}
-            onChange={onTextInputChange(setImageUrl)}
+            onChange={useCallback(onTextInputChange(setImageUrl), [
+              setImageUrl,
+            ])}
           />
 
           <MemeContainer justifyContent="center">

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -152,6 +152,7 @@ describe('<App />', () => {
   };
 
   const testImageUrl = 'https://test.url/this_is_test_image.png';
+
   it('should set imageSrc on valid image url change', () => {
     const component = mount(<App />);
 

--- a/src/components/__tests__/__snapshots__/image-url-input.test.js.snap
+++ b/src/components/__tests__/__snapshots__/image-url-input.test.js.snap
@@ -1,24 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ImageUrlInput /> should match snapshot when Input not visible 1`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={400}
-  transitionName="image-url"
-/>
+<CSSTransition
+  classNames="image-url"
+  in={false}
+  mountOnEnter={true}
+  timeout={
+    Object {
+      "enter": 300,
+      "exit": 400,
+    }
+  }
+  unmountOnExit={true}
+>
+  <TransitionContainer
+    flexDirection="column"
+    key="image-url-input-container"
+    px={3}
+  >
+    <Styled(Styled(styled.div))
+      as="input"
+      border="1px solid"
+      borderRadius={3}
+      fontSize={1}
+      mb={3}
+      mx={0}
+      onChange={[MockFunction]}
+      placeholder="Image URL..."
+      px={3}
+      py={2}
+      variant="primary"
+    />
+  </TransitionContainer>
+</CSSTransition>
 `;
 
 exports[`<ImageUrlInput /> should match snapshot when Input should be visible 1`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={400}
-  transitionName="image-url"
+<CSSTransition
+  classNames="image-url"
+  in={true}
+  mountOnEnter={true}
+  timeout={
+    Object {
+      "enter": 300,
+      "exit": 400,
+    }
+  }
+  unmountOnExit={true}
 >
   <TransitionContainer
     flexDirection="column"
@@ -40,5 +68,5 @@ exports[`<ImageUrlInput /> should match snapshot when Input should be visible 1`
       variant="primary"
     />
   </TransitionContainer>
-</CSSTransitionGroup>
+</CSSTransition>
 `;

--- a/src/components/__tests__/__snapshots__/image-url-input.test.js.snap
+++ b/src/components/__tests__/__snapshots__/image-url-input.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ImageUrlInput /> should match snapshot when Input not visible 1`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={400}
+  transitionName="image-url"
+/>
+`;
+
+exports[`<ImageUrlInput /> should match snapshot when Input should be visible 1`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={400}
+  transitionName="image-url"
+>
+  <TransitionContainer
+    flexDirection="column"
+    key="image-url-input-container"
+    px={3}
+  >
+    <Styled(Styled(styled.div))
+      as="input"
+      border="1px solid"
+      borderRadius={3}
+      fontSize={1}
+      mb={3}
+      mx={0}
+      onChange={[MockFunction]}
+      placeholder="Image URL..."
+      px={3}
+      py={2}
+      value="http://test.url.com"
+      variant="primary"
+    />
+  </TransitionContainer>
+</CSSTransitionGroup>
+`;

--- a/src/components/__tests__/image-url-input.test.js
+++ b/src/components/__tests__/image-url-input.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ImageUrlInput from '../image-url-input';
+import { Input } from '../';
+
+describe('<ImageUrlInput />', () => {
+  const getComponent = props =>
+    shallow(<ImageUrlInput onChange={jest.fn()} {...props} />);
+
+  it('should match snapshot when Input not visible', () => {
+    expect(getComponent()).toMatchSnapshot();
+  });
+
+  it('should match snapshot when Input should be visible', () => {
+    expect(
+      getComponent({ visible: true, value: 'http://test.url.com' }),
+    ).toMatchSnapshot();
+  });
+
+  it('should invoke onChange Prop', () => {
+    const onChangeMock = jest.fn();
+    const component = getComponent({
+      visible: true,
+      onChange: onChangeMock,
+    });
+
+    expect(onChangeMock).toHaveBeenCalledTimes(0);
+    const input = component.find(Input);
+    const value = 'https://test.test';
+    input.simulate('change', value);
+
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+    expect(onChangeMock).toHaveBeenCalledWith(value);
+  });
+});

--- a/src/components/image-url-input.js
+++ b/src/components/image-url-input.js
@@ -6,7 +6,7 @@ import { Flex } from 'rebass';
 
 import { Input } from './';
 
-const ImageUrlInput = ({ visible, value, onChange, transitionName }) => {
+const ImageUrlInput = ({ visible, transitionName, ...rest }) => {
   const TransitionContainer = useMemo(
     () =>
       styled(Flex)`
@@ -48,12 +48,7 @@ const ImageUrlInput = ({ visible, value, onChange, transitionName }) => {
           px={3}
           key="image-url-input-container"
         >
-          <Input
-            variant="primary"
-            placeholder="Image URL..."
-            value={value}
-            onChange={onChange}
-          />
+          <Input variant="primary" placeholder="Image URL..." {...rest} />
         </TransitionContainer>
       )}
     </ReactCSSTransitionGroup>

--- a/src/components/image-url-input.js
+++ b/src/components/image-url-input.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import styled from 'styled-components/macro';
@@ -7,29 +7,34 @@ import { Flex } from 'rebass';
 import { Input } from './';
 
 const ImageUrlInput = ({ visible, value, onChange, transitionName }) => {
-  const TransitionContainer = styled(Flex)`
-    &.${transitionName}-enter {
-      opacity: 0.01;
-      max-height: 0;
-    }
+  const TransitionContainer = useMemo(
+    () =>
+      styled(Flex)`
+        &.${transitionName}-enter {
+          opacity: 0.01;
+          max-height: 0;
+        }
 
-    &.${transitionName}-enter.${transitionName}-enter-active {
-      opacity: 1;
-      transition: max-height 200ms ease-out, opacity 300ms ease-in 50ms;
-      max-height: 100px;
-    }
+        &.${transitionName}-enter.${transitionName}-enter-active {
+          opacity: 1;
+          transition: max-height 200ms ease-out, opacity 300ms ease-in 50ms;
+          max-height: 100px;
+        }
 
-    &.${transitionName}-leave {
-      opacity: 1;
-      max-height: 100px;
-    }
+        &.${transitionName}-leave {
+          opacity: 1;
+          max-height: 100px;
+        }
 
-    &.${transitionName}-leave.${transitionName}-leave-active {
-      opacity: 0.01;
-      transition: max-height 400ms ease-out 100ms, opacity 300ms ease-in;
-      max-height: 0;
-    }
-  `;
+        &.${transitionName}-leave.${transitionName}-leave-active {
+          opacity: 0.01;
+          transition: max-height 400ms ease-out 100ms, opacity 300ms ease-in;
+          max-height: 0;
+        }
+      `,
+    [transitionName],
+  );
+  TransitionContainer.displayName = 'TransitionContainer';
 
   return (
     <ReactCSSTransitionGroup

--- a/src/components/image-url-input.js
+++ b/src/components/image-url-input.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import styled from 'styled-components/macro';
+import { Flex } from 'rebass';
+
+import { Input } from './';
+
+const ImageUrlInput = ({ visible, value, onChange, transitionName }) => {
+  const TransitionContainer = styled(Flex)`
+    &.${transitionName}-enter {
+      opacity: 0.01;
+      max-height: 0;
+    }
+
+    &.${transitionName}-enter.${transitionName}-enter-active {
+      opacity: 1;
+      transition: max-height 200ms ease-out, opacity 300ms ease-in 50ms;
+      max-height: 100px;
+    }
+
+    &.${transitionName}-leave {
+      opacity: 1;
+      max-height: 100px;
+    }
+
+    &.${transitionName}-leave.${transitionName}-leave-active {
+      opacity: 0.01;
+      transition: max-height 400ms ease-out 100ms, opacity 300ms ease-in;
+      max-height: 0;
+    }
+  `;
+
+  return (
+    <ReactCSSTransitionGroup
+      transitionName={transitionName}
+      transitionEnterTimeout={300}
+      transitionLeaveTimeout={400}
+    >
+      {visible && (
+        <TransitionContainer
+          flexDirection="column"
+          px={3}
+          key="image-url-input-container"
+        >
+          <Input
+            variant="primary"
+            placeholder="Image URL..."
+            value={value}
+            onChange={onChange}
+          />
+        </TransitionContainer>
+      )}
+    </ReactCSSTransitionGroup>
+  );
+};
+
+ImageUrlInput.propTypes = {
+  visible: PropTypes.bool,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  transitionName: PropTypes.string,
+};
+
+ImageUrlInput.defaultProps = {
+  visible: false,
+  transitionName: 'image-url',
+};
+
+export default ImageUrlInput;

--- a/src/components/image-url-input.js
+++ b/src/components/image-url-input.js
@@ -1,57 +1,62 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import { CSSTransition } from 'react-transition-group';
 import styled from 'styled-components/macro';
 import { Flex } from 'rebass';
 
 import { Input } from './';
 
-const ImageUrlInput = ({ visible, transitionName, ...rest }) => {
+const TransitionTimeout = {
+  enter: 300,
+  exit: 400,
+};
+
+const ImageUrlInput = ({ visible, className, ...rest }) => {
   const TransitionContainer = useMemo(
     () =>
       styled(Flex)`
-        &.${transitionName}-enter {
+        &.${className}-enter {
           opacity: 0.01;
           max-height: 0;
         }
 
-        &.${transitionName}-enter.${transitionName}-enter-active {
+        &.${className}-enter-active {
           opacity: 1;
           transition: max-height 200ms ease-out, opacity 300ms ease-in 50ms;
           max-height: 100px;
         }
 
-        &.${transitionName}-leave {
+        &.${className}-exit {
           opacity: 1;
           max-height: 100px;
         }
 
-        &.${transitionName}-leave.${transitionName}-leave-active {
+        &.${className}-exit-active {
           opacity: 0.01;
           transition: max-height 400ms ease-out 100ms, opacity 300ms ease-in;
           max-height: 0;
         }
       `,
-    [transitionName],
+    [className],
   );
   TransitionContainer.displayName = 'TransitionContainer';
 
   return (
-    <ReactCSSTransitionGroup
-      transitionName={transitionName}
-      transitionEnterTimeout={300}
-      transitionLeaveTimeout={400}
+    <CSSTransition
+      in={visible}
+      classNames={className}
+      timeout={TransitionTimeout}
+      mountOnEnter
+      unmountOnExit
     >
-      {visible && (
-        <TransitionContainer
-          flexDirection="column"
-          px={3}
-          key="image-url-input-container"
-        >
-          <Input variant="primary" placeholder="Image URL..." {...rest} />
-        </TransitionContainer>
-      )}
-    </ReactCSSTransitionGroup>
+      <TransitionContainer
+        flexDirection="column"
+        px={3}
+        key="image-url-input-container"
+      >
+        <Input variant="primary" placeholder="Image URL..." {...rest} />
+      </TransitionContainer>
+    </CSSTransition>
   );
 };
 
@@ -59,12 +64,12 @@ ImageUrlInput.propTypes = {
   visible: PropTypes.bool,
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  transitionName: PropTypes.string,
+  className: PropTypes.string,
 };
 
 ImageUrlInput.defaultProps = {
   visible: false,
-  transitionName: 'image-url',
+  className: 'image-url',
 };
 
 export default ImageUrlInput;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,3 +4,4 @@ export { default as Logo } from './logo';
 export { default as Input } from './input';
 export { default as Badge } from './badge';
 export { default as Meme } from './meme';
+export { default as ImageUrlInput } from './image-url-input';

--- a/src/components/meme.js
+++ b/src/components/meme.js
@@ -38,7 +38,14 @@ const MemeAttributionText = styled(Text)`
   text-decoration: none;
 `;
 
-const Meme = ({ imageSrc, topLabel, bottomLabel, isMobile, forwardedRef }) => {
+const Meme = ({
+  imageSrc,
+  topLabel,
+  bottomLabel,
+  isMobile,
+  onLoad,
+  forwardedRef,
+}) => {
   const [dimensions, setDimensions] = useState({});
 
   useEffect(() => {
@@ -52,9 +59,10 @@ const Meme = ({ imageSrc, topLabel, bottomLabel, isMobile, forwardedRef }) => {
         width = maxWidth;
       }
       setDimensions({ width, height });
+      onLoad();
     };
     image.src = imageSrc;
-  }, [imageSrc, isMobile]);
+  }, [imageSrc, isMobile, onLoad]);
 
   const textProps = {
     fontSize: isMobile ? 2 : 5,
@@ -90,6 +98,7 @@ Meme.propTypes = {
   topLabel: PropTypes.string,
   bottomLabel: PropTypes.string,
   isMobile: PropTypes.bool,
+  onLoad: PropTypes.func,
   forwardedRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
@@ -98,6 +107,7 @@ Meme.propTypes = {
 
 Meme.defaultProps = {
   isMobile: false,
+  onLoad: () => null,
 };
 
 const MemeWithRef = forwardRef((props, ref) => (

--- a/src/utils/__tests__/is-image-url.test.js
+++ b/src/utils/__tests__/is-image-url.test.js
@@ -1,0 +1,30 @@
+import isImage from 'is-image';
+
+import isImageUrl from '../is-image-url';
+
+jest.mock('is-image', () => jest.fn());
+
+describe('isImageUrl', () => {
+  afterEach(() => {
+    isImage.mockClear();
+  });
+
+  it(`should return false when not allowed protocol`, () => {
+    isImage.mockImplementation(() => true);
+    expect(isImageUrl('ftp://test:test')).toEqual(false);
+  });
+
+  [false, true].forEach(isImageResult =>
+    it(`should return ${isImageResult} when isImage returns ${isImageResult}`, () => {
+      isImage.mockImplementation(() => isImageResult);
+      expect(isImageUrl('http://test.url/pathname')).toEqual(isImageResult);
+    }),
+  );
+
+  it(`should return false when isImage throws`, () => {
+    isImage.mockImplementation(() => {
+      throw new Error();
+    });
+    expect(isImageUrl('http://test.url/pathname')).toEqual(false);
+  });
+});

--- a/src/utils/__tests__/is-image-url.test.js
+++ b/src/utils/__tests__/is-image-url.test.js
@@ -9,7 +9,7 @@ describe('isImageUrl', () => {
     isImage.mockClear();
   });
 
-  it(`should return false when not allowed protocol`, () => {
+  it(`should return false when protocol is not allowed`, () => {
     isImage.mockImplementation(() => true);
     expect(isImageUrl('ftp://test:test')).toEqual(false);
   });

--- a/src/utils/is-image-url.js
+++ b/src/utils/is-image-url.js
@@ -1,11 +1,10 @@
-import { parse } from 'url';
 import isImage from 'is-image';
 
 const allowedProtocols = ['http:', 'https:'];
 
 const isImageUrl = urlStr => {
   try {
-    const { protocol, pathname } = parse(urlStr);
+    const { protocol, pathname } = new URL(urlStr);
     return allowedProtocols.includes(protocol) && isImage(pathname);
   } catch {
     return false;

--- a/src/utils/is-image-url.js
+++ b/src/utils/is-image-url.js
@@ -1,0 +1,15 @@
+import { parse } from 'url';
+import isImage from 'is-image';
+
+const allowedProtocols = ['http:', 'https:'];
+
+const isImageUrl = urlStr => {
+  try {
+    const { protocol, pathname } = parse(urlStr);
+    return allowedProtocols.includes(protocol) && isImage(pathname);
+  } catch {
+    return false;
+  }
+};
+
+export default isImageUrl;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,7 +1798,7 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3, asap@~2.0.6:
+asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -2439,11 +2439,6 @@ case-sensitive-paths-webpack-plugin@2.2.0:
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz#3371ef6365ef9c25fa4b81c16ace0e9c7dc58c3e"
   integrity sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g==
 
-caseless@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
-  integrity sha1-cVuW6phBWTzDMGeSP17GDr2k99c=
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -2755,7 +2750,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0:
+concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -4880,15 +4875,6 @@ htmlparser2@^3.3.0, htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
-http-basic@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-2.5.1.tgz#8ce447bdb5b6c577f8a63e3fa78056ec4bb4dbfb"
-  integrity sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=
-  dependencies:
-    caseless "~0.11.0"
-    concat-stream "^1.4.6"
-    http-response-object "^1.0.0"
-
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -4927,11 +4913,6 @@ http-proxy@^1.17.0:
     eventemitter3 "^3.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
-
-http-response-object@^1.0.0, http-response-object@^1.0.1, http-response-object@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-1.1.0.tgz#a7c4e75aae82f3bb4904e4f43f615673b4d518c3"
-  integrity sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -5031,7 +5012,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-image-extensions@^1.0.1:
+image-extensions@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/image-extensions/-/image-extensions-1.1.0.tgz#b8e6bf6039df0056e333502a00b6637a3105d894"
   integrity sha1-uOa/YDnfAFbjM1AqALZjejEF2JQ=
@@ -5360,21 +5341,12 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-image-url@1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/is-image-url/-/is-image-url-1.1.8.tgz#aa62bf9757c5be540226999c74c3a21ada98b83c"
-  integrity sha1-qmK/l1fFvlQCJpmcdMOiGtqYuDw=
+is-image@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-image/-/is-image-3.0.0.tgz#f183431372f6f8caf7cda316a0a6dea4d41926dd"
+  integrity sha512-NNPLvwKZ/hqx1Wv+ayKvVeDOylIapVKSxK/guzmB9doAk0FEdK0KqFKbnwNbuMLEPqEY4NaBhxzB4e98fVOq2Q==
   dependencies:
-    is-image "^1.0.1"
-    is-url "^1.2.1"
-    sync-request "^2.1.0"
-
-is-image@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-image/-/is-image-1.0.1.tgz#6fd51a752a1a111506d060d952118b0b989b426e"
-  integrity sha1-b9UadSoaERUG0GDZUhGLC5ibQm4=
-  dependencies:
-    image-extensions "^1.0.1"
+    image-extensions "^1.1.0"
 
 is-number-object@^1.0.3:
   version "1.0.3"
@@ -5491,11 +5463,6 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-
-is-url@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
-  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
@@ -7356,11 +7323,6 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
-
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -8421,13 +8383,6 @@ promise@8.0.2:
   dependencies:
     asap "~2.0.6"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 prompts@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.0.4.tgz#179f9d4db3128b9933aa35f93a800d8fce76a682"
@@ -8545,11 +8500,6 @@ qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-qs@^6.1.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
-  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -9589,14 +9539,6 @@ space-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.3.tgz#bc6500e116d13285a94b59b58c44c7f045fe6124"
   integrity sha512-/M5RAdBuQlSDPNfA5ube+fkHbHyY08pMuADLmsAQURzo56w90r681oiOoz3o3ZQyWdSeNucpTFjL+Ggd5qui3w==
 
-spawn-sync@^1.0.1:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
-  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
-
 spdx-correct@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
@@ -9966,16 +9908,6 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
-sync-request@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-2.2.0.tgz#a7bd2c112fa09463eb9149cff0e9d428c479768f"
-  integrity sha1-p70sES+glGPrkUnP8OnUKMR5do8=
-  dependencies:
-    concat-stream "^1.4.7"
-    http-response-object "^1.0.1"
-    spawn-sync "^1.0.1"
-    then-request "^2.0.1"
-
 synchronous-promise@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.7.tgz#3574b3d2fae86b145356a4b89103e1577f646fe3"
@@ -10055,18 +9987,6 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
-
-then-request@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/then-request/-/then-request-2.2.0.tgz#6678b32fa0ca218fe569981bbd8871b594060d81"
-  integrity sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=
-  dependencies:
-    caseless "~0.11.0"
-    concat-stream "^1.4.7"
-    http-basic "^2.5.1"
-    http-response-object "^1.1.0"
-    promise "^7.1.1"
-    qs "^6.1.0"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -10420,7 +10340,7 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url@^0.11.0:
+url@0.11.0, url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,7 +1798,7 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.6:
+asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -2439,6 +2439,11 @@ case-sensitive-paths-webpack-plugin@2.2.0:
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz#3371ef6365ef9c25fa4b81c16ace0e9c7dc58c3e"
   integrity sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g==
 
+caseless@~0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
+  integrity sha1-cVuW6phBWTzDMGeSP17GDr2k99c=
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -2448,6 +2453,11 @@ ccount@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
   integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
+
+chain-function@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
+  integrity sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg==
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -2745,7 +2755,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -3465,6 +3475,13 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-serializer@0, dom-serializer@~0.1.1:
   version "0.1.1"
@@ -4863,6 +4880,15 @@ htmlparser2@^3.3.0, htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
+http-basic@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-2.5.1.tgz#8ce447bdb5b6c577f8a63e3fa78056ec4bb4dbfb"
+  integrity sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=
+  dependencies:
+    caseless "~0.11.0"
+    concat-stream "^1.4.6"
+    http-response-object "^1.0.0"
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -4901,6 +4927,11 @@ http-proxy@^1.17.0:
     eventemitter3 "^3.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+http-response-object@^1.0.0, http-response-object@^1.0.1, http-response-object@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-1.1.0.tgz#a7c4e75aae82f3bb4904e4f43f615673b4d518c3"
+  integrity sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -4999,6 +5030,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+image-extensions@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/image-extensions/-/image-extensions-1.1.0.tgz#b8e6bf6039df0056e333502a00b6637a3105d894"
+  integrity sha1-uOa/YDnfAFbjM1AqALZjejEF2JQ=
 
 immer@1.10.0:
   version "1.10.0"
@@ -5324,6 +5360,22 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-image-url@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/is-image-url/-/is-image-url-1.1.8.tgz#aa62bf9757c5be540226999c74c3a21ada98b83c"
+  integrity sha1-qmK/l1fFvlQCJpmcdMOiGtqYuDw=
+  dependencies:
+    is-image "^1.0.1"
+    is-url "^1.2.1"
+    sync-request "^2.1.0"
+
+is-image@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-image/-/is-image-1.0.1.tgz#6fd51a752a1a111506d060d952118b0b989b426e"
+  integrity sha1-b9UadSoaERUG0GDZUhGLC5ibQm4=
+  dependencies:
+    image-extensions "^1.0.1"
+
 is-number-object@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
@@ -5439,6 +5491,11 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url@^1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
@@ -6503,7 +6560,7 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7298,6 +7355,11 @@ os-locale@^3.0.0:
     execa "^1.0.0"
     lcid "^2.0.0"
     mem "^4.0.0"
+
+os-shim@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
+  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
 
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -8359,6 +8421,13 @@ promise@8.0.2:
   dependencies:
     asap "~2.0.6"
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 prompts@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.0.4.tgz#179f9d4db3128b9933aa35f93a800d8fce76a682"
@@ -8376,7 +8445,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.4, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8477,6 +8546,11 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+qs@^6.1.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -8551,6 +8625,13 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-addons-css-transition-group@15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-css-transition-group/-/react-addons-css-transition-group-15.6.2.tgz#9e4376bcf40b5217d14ec68553081cee4b08a6d6"
+  integrity sha1-nkN2vPQLUhfRTsaFUwgc7ksIptY=
+  dependencies:
+    react-transition-group "^1.2.0"
 
 react-app-polyfill@^1.0.0:
   version "1.0.0"
@@ -8687,6 +8768,17 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.13.6"
+
+react-transition-group@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
+  integrity sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.6"
+    warning "^3.0.0"
 
 react@16.8.6:
   version "16.8.6"
@@ -9497,6 +9589,14 @@ space-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.3.tgz#bc6500e116d13285a94b59b58c44c7f045fe6124"
   integrity sha512-/M5RAdBuQlSDPNfA5ube+fkHbHyY08pMuADLmsAQURzo56w90r681oiOoz3o3ZQyWdSeNucpTFjL+Ggd5qui3w==
 
+spawn-sync@^1.0.1:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
+
 spdx-correct@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
@@ -9866,6 +9966,16 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
+sync-request@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-2.2.0.tgz#a7bd2c112fa09463eb9149cff0e9d428c479768f"
+  integrity sha1-p70sES+glGPrkUnP8OnUKMR5do8=
+  dependencies:
+    concat-stream "^1.4.7"
+    http-response-object "^1.0.1"
+    spawn-sync "^1.0.1"
+    then-request "^2.0.1"
+
 synchronous-promise@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.7.tgz#3574b3d2fae86b145356a4b89103e1577f646fe3"
@@ -9945,6 +10055,18 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+then-request@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/then-request/-/then-request-2.2.0.tgz#6678b32fa0ca218fe569981bbd8871b594060d81"
+  integrity sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=
+  dependencies:
+    caseless "~0.11.0"
+    concat-stream "^1.4.7"
+    http-basic "^2.5.1"
+    http-response-object "^1.1.0"
+    promise "^7.1.1"
+    qs "^6.1.0"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -10455,6 +10577,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.5.0:
   version "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,11 +2449,6 @@ ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
   integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
 
-chain-function@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
-  integrity sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg==
-
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3471,7 +3466,7 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.2.0:
+dom-helpers@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
@@ -6527,7 +6522,7 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -8400,7 +8395,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.4, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8576,13 +8571,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-css-transition-group@15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-css-transition-group/-/react-addons-css-transition-group-15.6.2.tgz#9e4376bcf40b5217d14ec68553081cee4b08a6d6"
-  integrity sha1-nkN2vPQLUhfRTsaFUwgc7ksIptY=
-  dependencies:
-    react-transition-group "^1.2.0"
-
 react-app-polyfill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.0.tgz#735c725c1d4261b710cb200c498789c8b80e0f74"
@@ -8719,16 +8707,14 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.13.6"
 
-react-transition-group@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
-  integrity sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==
+react-transition-group@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.0.1.tgz#8cb8d58763e259da465385bb83b3b41b3ecba629"
+  integrity sha512-SsLcBYhO4afXJC9esL8XMxi/y0ZvEc7To0TvtrBELqzpjXQHPZOTxvuPh2/4EhYc0uSMfp2SExIxsyJ0pBdNzg==
   dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
+    dom-helpers "^3.4.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@16.8.6:
   version "16.8.6"
@@ -10497,13 +10483,6 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
-  dependencies:
-    loose-envify "^1.0.0"
 
 watchpack@^1.5.0:
   version "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10340,7 +10340,7 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url@0.11.0, url@^0.11.0:
+url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=


### PR DESCRIPTION
Add generating meme from URL functionality.

There are two key points here.
1. Since CORS might not be enabled for the url of the image
we bypass it by sending the image's url to our backend endpoint
which proxies the image request.

2. Use `useLayoutEffect` rather than `useEffect` for setting
the image src from image url, mainly because (currently)
`useEffect` can't be tested in our case. The thing is that
effects are executed after the render is committed to the screen,
while layout effect are run before the DOM is painted.